### PR TITLE
Prepare 0.17.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ repository = "https://github.com/briansmith/ring"
 rust-version = "1.63.0"
 
 # Keep in sync with `links` below.
-version = "0.17.10"
+version = "0.17.11-alpha1"
 
 # Keep in sync with `version` above.
 #
 # build.rs verifies that this equals "ring_core_{major}_{minor}_{patch}_{pre}"
 # as keeping this in sync with the symbol prefixing is crucial for ensuring
 # the safety of multiple versions of *ring* being used in a program.
-links = "ring_core_0_17_10_"
+links = "ring_core_0_17_11_alpha1"
 
 include = [
     "LICENSE",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ repository = "https://github.com/briansmith/ring"
 rust-version = "1.63.0"
 
 # Keep in sync with `links` below.
-version = "0.17.11-alpha1"
+version = "0.17.11"
 
 # Keep in sync with `version` above.
 #
 # build.rs verifies that this equals "ring_core_{major}_{minor}_{patch}_{pre}"
 # as keeping this in sync with the symbol prefixing is crucial for ensuring
 # the safety of multiple versions of *ring* being used in a program.
-links = "ring_core_0_17_11_alpha1"
+links = "ring_core_0_17_11_"
 
 include = [
     "LICENSE",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Brian Smith <brian@briansmith.org>"]
 build = "build.rs"
 categories = ["cryptography", "no-std"]
 description = "An experiment."


### PR DESCRIPTION
Following Brian's suggestion, I'll first release 0.17.11-alpha1 and then check the rustls CI against that. If that checks out, I'll release 0.17.11.

A post-hoc review of the administrative changes in #1 may a good idea; happy to fold any remedial changes into this.

## Release notes:

This is an administrative release, which is functionally equivalent to 0.17.10. It changes the crate repository to https://github.com/ctz/ring where this project will receive future security maintenance.